### PR TITLE
Configurable options, allow custom highlighted class

### DIFF
--- a/lib/builders/html_builder.rb
+++ b/lib/builders/html_builder.rb
@@ -1,16 +1,6 @@
 module Navigasmic
   class HtmlNavigationBuilder
 
-    @@classnames = {
-      :with_group => 'with-group',
-      :disabled => 'disabled',
-      :highlighted => 'highlighted'
-    }
-    @@wrapper_tag = :ul
-    @@group_tag = :ul
-    @@item_tag = :li
-    @@label_tag = :span
-
     attr_accessor :template, :name, :items
 
     def initialize(template, name, options = {}, &proc)
@@ -20,22 +10,22 @@ module Navigasmic
 
     def render(options, &proc)
       buffer = template.capture(self, &proc)
-      template.concat(template.content_tag(@@wrapper_tag, buffer, options))
+      template.concat(template.content_tag(Navigasmic.wrapper_tag, buffer, options))
     end
 
     def group(label = nil, options = {}, &proc)
       raise ArgumentError, "Missing block" unless block_given?
 
       options[:html] ||= {}
-      options[:html][:class] = template.add_html_class(options[:html][:class], @@classnames[:with_group])
-      options[:html][:id] ||= label.to_s.gsub(/\s/, '_').underscore unless label.blank? || options[:html].has_key?(:id) 
+      options[:html][:class] = template.add_html_class(options[:html][:class], Navigasmic.with_group_class)
+      options[:html][:id] ||= label.to_s.gsub(/\s/, '_').underscore unless label.blank? || options[:html].has_key?(:id)
 
       buffer = template.capture(self, &proc)
-      group = template.content_tag(@@group_tag, buffer)
+      group = template.content_tag(Navigasmic.group_tag, buffer)
       label = label_for_group(label) unless label.blank?
 
       visible = options[:hidden_unless].nil? ? true : options[:hidden_unless].is_a?(Proc) ? template.instance_eval(&options[:hidden_unless]) : options[:hidden_unless]
-      visible ? template.content_tag(@@item_tag, (label.to_s + group).html_safe, options.delete(:html)) : ''
+      visible ? template.content_tag(Navigasmic.item_tag, (label.to_s + group).html_safe, options.delete(:html)) : ''
     end
 
     def item(label, options = {}, &proc)
@@ -44,25 +34,25 @@ module Navigasmic
       item = NavigationItem.new(label, options, template)
 
       options[:html] ||= {}
-      options[:html][:id] = label.to_s.gsub(/\s/, '_').underscore unless options[:html].has_key?(:id) 
+      options[:html][:id] = label.to_s.gsub(/\s/, '_').underscore unless options[:html].has_key?(:id)
 
-      options[:html][:class] = template.add_html_class(options[:html][:class], @@classnames[:disabled]) if item.disabled?
-      options[:html][:class] = template.add_html_class(options[:html][:class], @@classnames[:highlighted]) if item.highlighted?(template.request.path, template.params, template)
+      options[:html][:class] = template.add_html_class(options[:html][:class], Navigasmic.disabled_class) if item.disabled?
+      options[:html][:class] = template.add_html_class(options[:html][:class], Navigasmic.highlighted_class) if item.highlighted?(template.request.path, template.params, template)
 
       label = label_for_item(label)
       link = item.link.is_a?(Proc) ? template.instance_eval(&item.link) : item.link
 
       label = template.link_to(label, link, options.delete(:link_html)) unless !item.link? || item.disabled?
 
-      item.hidden? ? '' : template.content_tag(@@item_tag, label + buffer, options.delete(:html))
+      item.hidden? ? '' : template.content_tag(Navigasmic.item_tag, label + buffer, options.delete(:html))
     end
 
     def label_for_group(label)
-      template.content_tag(@@label_tag, label.to_s)
+      template.content_tag(Navigasmic.label_tag, label.to_s)
     end
 
     def label_for_item(label)
-      template.content_tag(@@label_tag, label.to_s)
+      template.content_tag(Navigasmic.label_tag, label.to_s)
     end
 
   end

--- a/lib/navigasmic.rb
+++ b/lib/navigasmic.rb
@@ -4,6 +4,39 @@ require 'builders/xml_builder'
 
 module Navigasmic #:nodoc:
 
+  mattr_accessor :with_group_class
+  @@with_group_class = 'with-group'
+
+  mattr_accessor :disabled_class
+  @@disabled = 'disabled'
+
+  mattr_accessor :highlighted_class
+  @@highlighted = 'highlighted'
+
+  mattr_accessor :wrapper_tag
+  @@wrapper_tag = :ul
+
+  mattr_accessor :group_tag
+  @@group_tag = :ul
+
+  mattr_accessor :item_tag
+  @@item_tag = :li
+
+  mattr_accessor :label_tag
+  @@label_tag = :span
+
+
+  # Configuration helper
+  #
+  # Example usage:
+  #
+  #   Navigasmic.setup do |config|
+  #     config.highlighted_class = 'active'
+  #   end
+  def self.setup
+    yield self
+  end
+
   # Semantic navigation helper methods
   #
   # Example Usage:


### PR DESCRIPTION
I wanted to use Navigasmic in a Twitter Bootstrap project which defaults to an `active` class for highlighted items. This patch adds a configuration helper to override tag names and class names that were hardcoded in the builder:

```
Navigasmic.setup do |config|
  config.highlighted_class = 'active'
end
```
