### PR TITLE
Unobtrusive rule checking

### DIFF
--- a/lib/navigasmic/core/item.rb
+++ b/lib/navigasmic/core/item.rb
@@ -35,7 +35,7 @@ class Navigasmic::Item
         when FalseClass then highlighted &= rule
         when Hash
           clean_unwanted_keys(rule).each do |key, value|
-            value.gsub!(/^\//, '') if key == :controller
+            value.gsub(/^\//, '') if key == :controller
             highlighted &= value == params[key].to_s
           end
         else raise 'highlighting rules should be an array containing any of/or a Boolean, String, Regexp, Hash or Proc'

--- a/spec/core/item_spec.rb
+++ b/spec/core/item_spec.rb
@@ -86,5 +86,11 @@ describe Navigasmic::Item do
       item.highlights_on?('/path', {}).should be(false)
       item.highlights_on?('/other_path', {}).should be(false)
     end
+
+    it "leaves controller paths alone (bug fix)" do
+      item = subject.new 'Label', {controller: '/foo'}, true
+      item.highlights_on?('/path', {})
+      item.link.should == {controller: '/foo'}
+    end
   end
 end


### PR DESCRIPTION
I have no insight into why this was originally removing the leading `/` from the controller path, but it is causing errors for me since the controller path `foo` is not the same as `/foo`.

Replacing `gsub!` with `gsub` leaves all specs passing.

Let me know if you need any more info on my use case.
