### PR TITLE
Remove date from gemspec

### DIFF
--- a/navigasmic.gemspec
+++ b/navigasmic.gemspec
@@ -6,7 +6,6 @@ Gem::Specification.new do |s|
 
   # General Gem Information
   s.name        = 'navigasmic'
-  s.date        = '2012-10-02'
   s.version     = Navigasmic::VERSION
   s.authors     = ['Jeremy Jackson']
   s.email       = ['jejacks0n@gmail.com']


### PR DESCRIPTION
It's not needed and makes it confusing to see on RubyGems.org.

Mentioned in #36.
