### PR TITLE
refactored spec expectations using `should` over to `expect`

### DIFF
--- a/spec/builders/list_builder_spec.rb
+++ b/spec/builders/list_builder_spec.rb
@@ -32,7 +32,7 @@ describe 'Navigasmic::Builder::ListBuilder', type: :helper do
         </ul>
       HTML
 
-      builder.render.should match(clean(html))
+      expect(builder.render).to match(clean(html))
     end
 
     it "handles builder configurations" do
@@ -67,7 +67,7 @@ describe 'Navigasmic::Builder::ListBuilder', type: :helper do
         </ul>
       HTML
 
-      builder.render.should match(clean(html))
+      expect(builder.render).to match(clean(html))
     end
 
     it "handles link_html of items" do
@@ -85,7 +85,7 @@ describe 'Navigasmic::Builder::ListBuilder', type: :helper do
         </ul>
       HTML
 
-      builder.render.should match(clean(html))
+      expect(builder.render).to match(clean(html))
     end
   end
 end

--- a/spec/builders/map_builder_spec.rb
+++ b/spec/builders/map_builder_spec.rb
@@ -25,7 +25,7 @@ describe 'Navigasmic::Builder::MapBuilder', type: :helper do
         </urlset>
       XML
 
-      builder.render.should match(clean(xml))
+      expect(builder.render).to match(clean(xml))
     end
 
     it "handles builder configurations" do
@@ -48,7 +48,7 @@ describe 'Navigasmic::Builder::MapBuilder', type: :helper do
         </urlset>
       XML
 
-      builder.render.should match(clean(xml))
+      expect(builder.render).to match(clean(xml))
     end
   end
 end

--- a/spec/core/builder_spec.rb
+++ b/spec/core/builder_spec.rb
@@ -7,7 +7,7 @@ describe 'Navigasmic::Builder::Base', type: :helper do
   describe "#group" do
 
     it "raises" do
-      lambda { subject.group }.should raise_error('Expected subclass to implement group')
+      expect { subject.group }.to raise_error('Expected subclass to implement group')
     end
 
   end
@@ -15,7 +15,7 @@ describe 'Navigasmic::Builder::Base', type: :helper do
   describe "#item" do
 
     it "raises" do
-      lambda { subject.item }.should raise_error('Expected subclass to implement item')
+      expect { subject.item }.to raise_error('Expected subclass to implement item')
     end
 
   end
@@ -23,7 +23,7 @@ describe 'Navigasmic::Builder::Base', type: :helper do
   describe "#render" do
 
     it "raises" do
-      lambda { subject.render }.should raise_error('Expected subclass to implement render')
+      expect { subject.render }.to raise_error('Expected subclass to implement render')
     end
 
   end

--- a/spec/core/configuration_spec.rb
+++ b/spec/core/configuration_spec.rb
@@ -3,19 +3,19 @@ require 'spec_helper'
 describe Navigasmic do
 
   it "has a configuration property" do
-    Navigasmic.configuration.should be(Navigasmic::Configuration)
+    expect(Navigasmic.configuration).to be(Navigasmic::Configuration)
   end
 
   describe ".setup" do
 
     it "is defined" do
-      Navigasmic.methods.should include(:setup)
+      expect(Navigasmic.methods).to include(:setup)
     end
 
     it "yields configuration" do
       config = nil
       Navigasmic.setup { |c| config = c }
-      config.should be(Navigasmic::Configuration)
+      expect(config).to be(Navigasmic::Configuration)
     end
 
   end
@@ -25,32 +25,32 @@ describe Navigasmic do
     subject { Navigasmic::Configuration }
 
     it "sets the default_builder to ListBuilder" do
-      subject.default_builder.should be(Navigasmic::Builder::ListBuilder)
+      expect(subject.default_builder).to be(Navigasmic::Builder::ListBuilder)
     end
 
     it "allows configuring builders" do
-      subject.builder_configurations.should be_a(Hash)
-      subject.builder_configurations.should include('Navigasmic::Builder::ListBuilder')
+      expect(subject.builder_configurations).to be_a(Hash)
+      expect(subject.builder_configurations).to include('Navigasmic::Builder::ListBuilder')
 
       subject.builder test_config: Navigasmic::Builder::ListBuilder do
       end
 
-      subject.builder_configurations['Navigasmic::Builder::ListBuilder'].should include(:test_config)
-      subject.builder_configurations['Navigasmic::Builder::ListBuilder'][:test_config].should be_a(Proc)
+      expect(subject.builder_configurations['Navigasmic::Builder::ListBuilder']).to include(:test_config)
+      expect(subject.builder_configurations['Navigasmic::Builder::ListBuilder'][:test_config]).to be_a(Proc)
     end
 
     it "allows naming builder configurations" do
     end
 
     it "allows defining navigation structures" do
-      subject.definitions.should be_a(Hash)
-      subject.definitions.should include(:primary)
+      expect(subject.definitions).to be_a(Hash)
+      expect(subject.definitions).to include(:primary)
 
       subject.semantic_navigation :test_definition do
       end
 
-      subject.definitions.should include(:test_definition)
-      subject.definitions[:test_definition].should be_a(Proc)
+      expect(subject.definitions).to include(:test_definition)
+      expect(subject.definitions[:test_definition]).to be_a(Proc)
     end
   end
 end

--- a/spec/core/item_spec.rb
+++ b/spec/core/item_spec.rb
@@ -7,105 +7,105 @@ describe Navigasmic::Item do
   describe "#hidden?" do
     it "returns true when it's not visible" do
       item = subject.new 'Label', {controller: 'controller'}, false
-      item.hidden?.should be(true)
+      expect(item.hidden?).to be true
     end
 
     it "returns false when it's visible" do
       item = subject.new 'Label', {controller: 'controller'}, true
-      item.hidden?.should be(false)
+      expect(item.hidden?).to be false
     end
   end
 
   describe "#disabled?" do
     it "returns true when it's disabled" do
       item = subject.new 'Label', {controller: 'controller'}, true, disabled_if: true
-      item.disabled?.should be(true)
+      expect(item.disabled?).to be true
     end
 
     it "returns false when it's not disabled" do
       item = subject.new 'Label', {controller: 'controller'}, true, disabled_if: false
-      item.disabled?.should be(false)
+      expect(item.disabled?).to be false
     end
   end
 
   describe "#link?" do
     it "returns true when there's a link" do
       item = subject.new 'Label', 'url', true
-      item.link?.should be(true)
+      expect(item.link?).to be true
     end
 
     it "returns false when there isn't a link" do
       item = subject.new 'Label', nil, true
-      item.link?.should be(false)
+      expect(item.link?).to be false
     end
 
     it "returns false when it's disabled" do
       item = subject.new 'Label', nil, true, disabled_if: true
-      item.link?.should be(false)
+      expect(item.link?).to be false
     end
   end
 
   describe "#calculate_highlighting_rules" do
     it "uses the item's link when no rules given" do
       item = subject.new 'Label', 'url', true
-      item.send(:calculate_highlighting_rules, nil).should eq(['url'])
+      expect(item.send(:calculate_highlighting_rules, nil)).to eq(['url'])
     end
 
     it "uses the given rules if any given" do
       item = subject.new 'Label', 'url', true, :highlights_on => false
-      item.send(:calculate_highlighting_rules, false).should eq([false])
+      expect(item.send(:calculate_highlighting_rules, false)).to eq([false])
 
       item = subject.new 'Label', 'url', true, :highlights_on => false
-      item.send(:calculate_highlighting_rules, ["/a", "/b"]).should eq(["/a", "/b"])
+      expect(item.send(:calculate_highlighting_rules, ["/a", "/b"])).to eq(["/a", "/b"])
     end
   end
 
   describe "#highlights_on?" do
     it "uses it's own link (as a string)" do
       item = subject.new 'Label', '/path', true
-      item.highlights_on?('/path', {}).should be(true)
-      item.highlights_on?('/other_path', {}).should be(false)
+      expect(item.highlights_on?('/path', {})).to be true
+      expect(item.highlights_on?('/other_path', {})).to be false
     end
 
     it "uses it's own path (as hash)" do
       item = subject.new 'Label', {controller: 'foo'}, true
-      item.highlights_on?('/path', {controller: 'foo'}).should be(true)
-      item.highlights_on?('/other_path', {controller: 'bar'}).should be(false)
+      expect(item.highlights_on?('/path', {controller: 'foo'})).to be true
+      expect(item.highlights_on?('/other_path', {controller: 'bar'})).to be false
     end
 
     it "highlights on multiple controllers" do
       item = subject.new 'Label', '/foo', true, highlights_on: [{controller: 'foo'}, {controller: 'bar'}]
-      item.highlights_on?('/path', {controller: 'foo'}).should be(true)
-      item.highlights_on?('/other_path', {controller: 'bar'}).should be(true)
-      item.highlights_on?('/other_path_entirely', {controller: 'baz'}).should be(false)
+      expect(item.highlights_on?('/path', {controller: 'foo'})).to be true
+      expect(item.highlights_on?('/other_path', {controller: 'bar'})).to be true
+      expect(item.highlights_on?('/other_path_entirely', {controller: 'baz'})).to be false
     end
 
     it "handles strings" do
       item = subject.new 'Label', '/foo', true, highlights_on: '/path'
-      item.highlights_on?('/path', {}).should be(true)
-      item.highlights_on?('/other_path', {}).should be(false)
+      expect(item.highlights_on?('/path', {})).to be true
+      expect(item.highlights_on?('/other_path', {})).to be false
     end
 
     it "handles regexp" do
       item = subject.new 'Label', '/foo', true, highlights_on: /^\/pa/
-      item.highlights_on?('/path', {}).should be(true)
-      item.highlights_on?('/other_path', {}).should be(false)
+      expect(item.highlights_on?('/path', {})).to be true
+      expect(item.highlights_on?('/other_path', {})).to be false
     end
 
     it "handles true/false" do
       item = subject.new 'Label', '/foo', true, highlights_on: true
-      item.highlights_on?('/path', {}).should be(true)
-      item.highlights_on?('/other_path', {}).should be(true)
+      expect(item.highlights_on?('/path', {})).to be true
+      expect(item.highlights_on?('/other_path', {})).to be true
 
       item = subject.new 'Label', '/foo', true, highlights_on: false
-      item.highlights_on?('/path', {}).should be(false)
-      item.highlights_on?('/other_path', {}).should be(false)
+      expect(item.highlights_on?('/path', {})).to be false
+      expect(item.highlights_on?('/other_path', {})).to be false
     end
 
     it "leaves controller paths alone (bug fix)" do
       item = subject.new 'Label', {controller: '/foo'}, true
       item.highlights_on?('/path', {})
-      item.link.should == {controller: '/foo'}
+      expect(item.link).to eq({controller: '/foo'})
     end
   end
 end

--- a/spec/rails/engine_spec.rb
+++ b/spec/rails/engine_spec.rb
@@ -3,19 +3,19 @@ require 'spec_helper'
 describe Navigasmic do
 
   it "is a module" do
-    Navigasmic.should be_a(Module)
+    expect(Navigasmic).to be_a(Module)
   end
 
   it "has a version" do
-    Navigasmic::VERSION.should be_a(String)
+    expect(Navigasmic::VERSION).to be_a(String)
   end
 
   it "defines ViewHelpers" do
-    Navigasmic::ViewHelpers.should be_a(Module)
+    expect(Navigasmic::ViewHelpers).to be_a(Module)
   end
 
   it "includes ViewHelpers in ActionView::Base" do
-    ActionView::Base.new.methods.should include(:semantic_navigation)
+    expect(ActionView::Base.new.methods).to include(:semantic_navigation)
   end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,6 @@ ENV['RAILS_ROOT'] = File.expand_path('../dummy', __FILE__)
 require File.expand_path('../dummy/config/environment', __FILE__)
 
 require 'rspec/rails'
-require 'rspec/autorun'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.


### PR DESCRIPTION
A quick refactoring to remove the RSpec 3.x deprecation warnings in case there isn't plans to continue using the `should` syntax.

[https://github.com/rspec/rspec-expectations/commit/dc8406b37eda6f58f9426dd8eec52fa7d7d186bc](https://github.com/rspec/rspec-expectations/commit/dc8406b37eda6f58f9426dd8eec52fa7d7d186bc)
