### PR TITLE
Handle `hidden_unless` for groups in `ListBuilder`

### DIFF
--- a/lib/navigasmic/builders/list_builder.rb
+++ b/lib/navigasmic/builders/list_builder.rb
@@ -51,14 +51,14 @@ module Navigasmic::Builder
       end
       return '' unless visible?(options)
 
-      concat(structure_for(label_or_options, false, options, &block))
+      concat(structure_for(label_or_options, false, options.except(:hidden_unless), &block))
     end
 
     def item(label, *args, &block)
       options = args.extract_options!
       options = flatten_and_eval_options(options)
       return '' unless visible?(options)
-      
+
       if label.is_a?(Proc)
         label = eval_in_context(&label)
       end

--- a/spec/builders/list_builder_spec.rb
+++ b/spec/builders/list_builder_spec.rb
@@ -87,5 +87,24 @@ describe 'Navigasmic::Builder::ListBuilder', type: :helper do
 
       expect(builder.render).to match(clean(html))
     end
+
+    it "handles hidden_unless for groups" do
+      builder = subject.new helper, :primary, {} do |n|
+        n.group(hidden_unless: false) { n.item "Label", '/path' }
+        n.group(hidden_unless: true) { n.item "Label 2", '/path2' }
+      end
+
+      html = <<-HTML
+        <ul class="semantic-navigation" id="primary">
+          <li class="has-nested">
+            <ul class="is-nested">
+              <li><a href="/path2"><span>Label 2</span></a></li>
+            </ul>
+          </li>
+        </ul>
+      HTML
+
+      expect(builder.render).to match(clean(html))
+    end
   end
 end


### PR DESCRIPTION
The `hidden_unless` option is supported by the list builder but is not
deleted from the options hash. It has to be deleted so it is not
displayed as an attribute of the html tag.

Without this pull request, the resulting HTML looks like

``` html
<li class="has-nested" hidden_unless="#<Proc:0x007f9041fd0bf0@./config/initializers/navigasmic.rb:7>">
```
